### PR TITLE
fix: `point` 도메인 버그 수정

### DIFF
--- a/src/main/java/org/zzin/splitfy/domain/point/controller/PointController.java
+++ b/src/main/java/org/zzin/splitfy/domain/point/controller/PointController.java
@@ -16,7 +16,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Closes #56 

<br>

## 📝 작업 내용(이미지 첨부 가능)
- 인증 미포함 버그 수정
- getUsersPoint 메서드에서 불필요한 PathVariable 제거
