### PR TITLE
refactor: Transaction 엔티티의 필드 타입을 Long에서 기본형 long으로 변경

### DIFF
--- a/src/main/java/org/zzin/splitfy/domain/transaction/entity/Transaction.java
+++ b/src/main/java/org/zzin/splitfy/domain/transaction/entity/Transaction.java
@@ -28,26 +28,26 @@ public class Transaction {
   private Long id;
 
   @Column(nullable = false)
-  private Long userId;
+  private long userId;
 
   @Column(nullable = false)
-  private Long amount;
+  private long amount;
 
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
   private TransactionType type;
 
   @Column(nullable = false)
-  private Long beforePoint;
+  private long beforePoint;
 
   @Column(nullable = false)
-  private Long afterPoint;
+  private long afterPoint;
 
   @CreatedDate
   @Column(nullable = false, updatable = false)
   private LocalDateTime transactionTime;
 
-  @Column(nullable = false, unique = true)
+  @Column(nullable = false)
   private String uuid;
 
   @Builder


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Closes #61 

<br>

## 📝 작업 내용(이미지 첨부 가능)
- Null safety 를 위하여 Transaction 엔티티의 필드 타입을 Long에서 기본형 long으로 변경
