### PR TITLE
refactor: `Point` 도메인의 서비스 파라미터 수정

### DIFF
--- a/src/main/java/org/zzin/splitfy/domain/point/Service/PointService.java
+++ b/src/main/java/org/zzin/splitfy/domain/point/Service/PointService.java
@@ -65,18 +65,19 @@ public class PointService {
    *
    * @param toUserId 수신자의 사용자 ID
    * @param amount   이체할 포인트 양 (양수여야 함)
-   * @param meId     송신자의 사용자 ID
+   * @param authUser 인증된 송신자 정보
    * @return TransferResponse — 요청한 이체 금액 및 송신자의 before/after 포인트 정보를 포함한 응답
    */
   @Transactional
-  public TransferResponse transferTo(long toUserId, long amount, long meId) {
+  public TransferResponse transferTo(long toUserId, long amount, AuthUser authUser) {
     String transactionUUID = UUID.randomUUID().toString();
-    PointTransferSummaryDTO pointChangeDetail = authInnerService.transferPoint(meId, toUserId,
+    PointTransferSummaryDTO pointChangeDetail = authInnerService.transferPoint(authUser.userId(),
+        toUserId,
         amount);
 
     var transferOutInfo = TransactionInfoDTO.builder()
         .transactionUUID(transactionUUID)
-        .userId(meId)
+        .userId(authUser.userId())
         .amount(amount)
         .beforePoint(pointChangeDetail.getSenderBeforePoint())
         .afterPoint(pointChangeDetail.getSenderAfterPoint())

--- a/src/main/java/org/zzin/splitfy/domain/point/controller/PointController.java
+++ b/src/main/java/org/zzin/splitfy/domain/point/controller/PointController.java
@@ -43,7 +43,7 @@ public class PointController {
   public CommonResponse<TransferResponse> transfer(@Valid @RequestBody TransferRequest request,
       @AuthenticationPrincipal AuthUser authUser) {
     TransferResponse response = pointService.transferTo(request.toUserId(), request.amount(),
-        authUser.userId());
+        authUser);
     return CommonResponse.success(response);
   }
 

--- a/src/test/java/org/zzin/splitfy/domain/point/PointServiceTest.java
+++ b/src/test/java/org/zzin/splitfy/domain/point/PointServiceTest.java
@@ -83,7 +83,7 @@ class PointServiceTest {
             .receiverAfterPoint(otherAfter)
             .build());
 
-    TransferResponse response = pointService.transferTo(toUserId, amount, meId);
+    TransferResponse response = pointService.transferTo(toUserId, amount, new AuthUser(meId));
 
     assertThat(response).isNotNull();
     assertThat(response.amount()).isEqualTo(amount);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Closes #71 

<br>

## 📝 작업 내용(이미지 첨부 가능)
- getPointBy() 메서드의 매개변수를 AuthUser로 변경
- deposit() 메서드의 매개변수를 AuthUser로 변경
- transferTo() 메서드의 매개변수를 AuthUser로 변경
