### PR TITLE
refactor: JWT 인증 필터 추가 및 인가 책임을 @PreAuthorize로 분리

### DIFF
--- a/src/main/java/org/zzin/splitfy/common/config/SecurityConfig.java
+++ b/src/main/java/org/zzin/splitfy/common/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package org.zzin.splitfy.common.config;
 
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,16 +12,21 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.zzin.splitfy.common.security.jwt.JwtAuthenticationFilter;
 import org.zzin.splitfy.common.security.jwt.JwtProperties;
 
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity(prePostEnabled = true)
+@RequiredArgsConstructor
 @EnableConfigurationProperties(JwtProperties.class)
 public class SecurityConfig {
+
+  private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -31,8 +37,9 @@ public class SecurityConfig {
             SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(auth -> auth
             .requestMatchers("/api/v1/auth/**").permitAll()
-            .anyRequest().authenticated()
+            .anyRequest().permitAll()
         )
+        .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
         .httpBasic(httpBasic -> httpBasic.disable())
         .formLogin(form -> form.disable())
         .headers(headers -> headers.frameOptions(frame -> frame.sameOrigin()));


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Closes #74

<br>

## 📝 작업 내용(이미지 첨부 가능)
- SecurityConfig에 JwtAuthenticationFilter 추가
- 전역 URL 인가는 permitAll로 설정하고, 인가는 @PreAuthorize 기반으로 관리