### PR TITLE
feat: 거래 내역 조회 API의 응답 형식을 CommonResponse로 변경

### DIFF
--- a/src/main/java/org/zzin/splitfy/domain/transaction/controller/TransactionController.java
+++ b/src/main/java/org/zzin/splitfy/domain/transaction/controller/TransactionController.java
@@ -2,6 +2,7 @@ package org.zzin.splitfy.domain.transaction.controller;
 
 import org.springframework.web.bind.annotation.RestController;
 import org.zzin.splitfy.common.dto.CommonPage;
+import org.zzin.splitfy.common.dto.CommonResponse;
 import org.zzin.splitfy.common.security.AuthUser;
 import org.zzin.splitfy.domain.transaction.dto.response.GetTransactionsByResponse;
 import org.zzin.splitfy.domain.transaction.service.TransactionService;
@@ -25,14 +26,14 @@ public class TransactionController {
   private final TransactionService transactionService;
 
   @GetMapping("/transactions")
-  public CommonPage<GetTransactionsByResponse> getTransactionsBy(
+  public CommonResponse<CommonPage<GetTransactionsByResponse>> getTransactionsBy(
       @AuthenticationPrincipal AuthUser authUser, @PageableDefault Pageable pageable) {
 
     var pageResult = transactionService.getTransactionsBy(
         authUser, pageable.getPageNumber(), pageable.getPageSize());
     Page<GetTransactionsByResponse> response = pageResult.map(GetTransactionsByResponse::fromDto);
 
-    return CommonPage.of(response);
+    return CommonResponse.success(CommonPage.of(response));
   }
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Closes #77 

<br>

## 📝 작업 내용(이미지 첨부 가능)
- 거래 내역 조회 API의 응답 형식을 CommonResponse로 변경
