### PR TITLE
refactor: payment 엔티티에 setId() 추가

### DIFF
--- a/src/main/java/org/zzin/splitfy/common/config/SecurityConfig.java
+++ b/src/main/java/org/zzin/splitfy/common/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
             SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(auth -> auth
             .requestMatchers("/api/v1/auth/**").permitAll()
-            .anyRequest().permitAll()
+            .anyRequest().authenticated()
         )
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
         .httpBasic(httpBasic -> httpBasic.disable())

--- a/src/main/java/org/zzin/splitfy/common/config/SecurityConfig.java
+++ b/src/main/java/org/zzin/splitfy/common/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package org.zzin.splitfy.common.config;
 
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,8 +18,6 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.zzin.splitfy.common.security.jwt.JwtAuthenticationFilter;
 import org.zzin.splitfy.common.security.jwt.JwtProperties;
-
-import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSecurity
@@ -38,7 +37,7 @@ public class SecurityConfig {
             SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(auth -> auth
             .requestMatchers("/api/v1/auth/**").permitAll()
-            .anyRequest().authenticated()
+            .anyRequest().permitAll()
         )
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
         .httpBasic(httpBasic -> httpBasic.disable())

--- a/src/main/java/org/zzin/splitfy/domain/auth/repository/AuthRepository.java
+++ b/src/main/java/org/zzin/splitfy/domain/auth/repository/AuthRepository.java
@@ -1,6 +1,8 @@
 package org.zzin.splitfy.domain.auth.repository;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.zzin.splitfy.domain.auth.entity.User;
 
@@ -11,4 +13,6 @@ public interface AuthRepository extends JpaRepository<User, Long> {
   boolean existsByEmail(String email);
 
   Optional<User> findByEmail(String email);
+
+  List<User> findByIdIn(Set<Long> ids);
 }

--- a/src/main/java/org/zzin/splitfy/domain/auth/service/AuthInnerService.java
+++ b/src/main/java/org/zzin/splitfy/domain/auth/service/AuthInnerService.java
@@ -1,5 +1,9 @@
 package org.zzin.splitfy.domain.auth.service;
 
+import java.util.Map;
+import java.util.Set;
+
 public interface AuthInnerService {
 
+  Map<Long, String> findByIdIn(Set<Long> userIds);
 }

--- a/src/main/java/org/zzin/splitfy/domain/auth/service/DefaultAuthInnerService.java
+++ b/src/main/java/org/zzin/splitfy/domain/auth/service/DefaultAuthInnerService.java
@@ -1,7 +1,25 @@
 package org.zzin.splitfy.domain.auth.service;
 
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.zzin.splitfy.domain.auth.entity.User;
+import org.zzin.splitfy.domain.auth.repository.AuthRepository;
 
 @Service
+@RequiredArgsConstructor
 public class DefaultAuthInnerService implements AuthInnerService {
+
+  private final AuthRepository authRepository;
+
+  @Override
+  public Map<Long, String> findByIdIn(Set<Long> userIds) {
+    if (userIds == null || userIds.isEmpty()) {
+      return Map.of();
+    }
+    return authRepository.findByIdIn(userIds).stream()
+        .collect(Collectors.toMap(User::getId, User::getUsername, (a, b) -> a));
+  }
 }

--- a/src/main/java/org/zzin/splitfy/domain/settlement/controller/SettlementController.java
+++ b/src/main/java/org/zzin/splitfy/domain/settlement/controller/SettlementController.java
@@ -2,15 +2,20 @@ package org.zzin.splitfy.domain.settlement.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.zzin.splitfy.common.dto.CommonPage;
 import org.zzin.splitfy.common.dto.CommonResponse;
 import org.zzin.splitfy.common.security.AuthUser;
 import org.zzin.splitfy.domain.settlement.dto.request.SettlementRequest;
+import org.zzin.splitfy.domain.settlement.dto.response.SettlementHistoryResponse;
 import org.zzin.splitfy.domain.settlement.dto.response.SettlementResponse;
 import org.zzin.splitfy.domain.settlement.service.SettlementService;
 
@@ -28,6 +33,15 @@ public class SettlementController {
       @Valid @RequestBody SettlementRequest request
   ) {
     SettlementResponse response = settlementService.createSettlement(authUser, request);
+    return CommonResponse.success(response);
+  }
+
+  @GetMapping("/me")
+  public CommonResponse<CommonPage<SettlementHistoryResponse>> getSettlementHistory(
+      @PageableDefault(size = 10, page = 0) Pageable pageable,
+      @AuthenticationPrincipal AuthUser authUser) {
+    CommonPage<SettlementHistoryResponse> response = settlementService.getSettlementHistory(
+        pageable, authUser);
     return CommonResponse.success(response);
   }
 }

--- a/src/main/java/org/zzin/splitfy/domain/settlement/dto/PaymentAllocationDto.java
+++ b/src/main/java/org/zzin/splitfy/domain/settlement/dto/PaymentAllocationDto.java
@@ -1,0 +1,19 @@
+package org.zzin.splitfy.domain.settlement.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import org.jspecify.annotations.Nullable;
+
+public record PaymentAllocationDto(
+    Long paymentId,
+    Long settlementId,
+    Long paidAmount,
+    Long payerId,
+    Long shareAmount,
+    String title,
+    @Nullable Long allocationUserId
+) {
+
+  @QueryProjection
+  public PaymentAllocationDto {
+  }
+}

--- a/src/main/java/org/zzin/splitfy/domain/settlement/dto/response/SettlementHistoryResponse.java
+++ b/src/main/java/org/zzin/splitfy/domain/settlement/dto/response/SettlementHistoryResponse.java
@@ -1,0 +1,17 @@
+package org.zzin.splitfy.domain.settlement.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.zzin.splitfy.domain.settlement.enums.SettlementStatus;
+
+public record SettlementHistoryResponse(
+    Long settlementId,
+    Long totalPaidAmount,
+    SettlementStatus status,
+    LocalDateTime issuedAt,
+    LocalDateTime succeededAt,
+    Long settlementAmount,
+    List<SettlementPaymentResponse> payments
+) {
+
+}

--- a/src/main/java/org/zzin/splitfy/domain/settlement/dto/response/SettlementPaymentResponse.java
+++ b/src/main/java/org/zzin/splitfy/domain/settlement/dto/response/SettlementPaymentResponse.java
@@ -1,0 +1,12 @@
+package org.zzin.splitfy.domain.settlement.dto.response;
+
+import java.util.List;
+
+public record SettlementPaymentResponse(
+    String title,
+    long paidAmount,
+    String payerName,
+    List<String> allocationNames
+) {
+
+}

--- a/src/main/java/org/zzin/splitfy/domain/settlement/entity/Payment.java
+++ b/src/main/java/org/zzin/splitfy/domain/settlement/entity/Payment.java
@@ -47,4 +47,8 @@ public class Payment {
     this.settlementId = settlementId;
   }
 
+  public void setId(Long id) {
+    this.id = id;
+  }
+
 }

--- a/src/main/java/org/zzin/splitfy/domain/settlement/entity/Payment.java
+++ b/src/main/java/org/zzin/splitfy/domain/settlement/entity/Payment.java
@@ -46,4 +46,5 @@ public class Payment {
   public void setSettlementId(long settlementId) {
     this.settlementId = settlementId;
   }
+
 }

--- a/src/main/java/org/zzin/splitfy/domain/settlement/entity/PaymentAllocations.java
+++ b/src/main/java/org/zzin/splitfy/domain/settlement/entity/PaymentAllocations.java
@@ -13,25 +13,21 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(name = "settlement_participants")
-public class SettlementParticipant {
+@Table(name = "payment_allocations")
+public class PaymentAllocations {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(name = "settlement_id", nullable = false)
-  private long settlementId;
+  @Column(name = "payment_id", nullable = false)
+  private long paymentId;
 
-  @Column(nullable = false)
-  private long participantId;
+  @Column(name = "user_id", nullable = false)
+  private long userId;
 
-  @Column
-  private long settlementAmount;
-
-  public SettlementParticipant(long settlementId, long participantId, long settlementAmount) {
-    this.settlementId = settlementId;
-    this.participantId = participantId;
-    this.settlementAmount = settlementAmount;
+  public PaymentAllocations(long paymentId, long userId) {
+    this.paymentId = paymentId;
+    this.userId = userId;
   }
 }

--- a/src/main/java/org/zzin/splitfy/domain/settlement/entity/Settlement.java
+++ b/src/main/java/org/zzin/splitfy/domain/settlement/entity/Settlement.java
@@ -2,6 +2,7 @@ package org.zzin.splitfy.domain.settlement.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
@@ -13,12 +14,14 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.zzin.splitfy.domain.settlement.enums.SettlementStatus;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "settlements")
+@EntityListeners(AuditingEntityListener.class)
 public class Settlement {
 
   @Id

--- a/src/main/java/org/zzin/splitfy/domain/settlement/entity/SettlementParticipant.java
+++ b/src/main/java/org/zzin/splitfy/domain/settlement/entity/SettlementParticipant.java
@@ -7,8 +7,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "settlement_participants")

--- a/src/main/java/org/zzin/splitfy/domain/settlement/mapper/SettlementHistoryMapper.java
+++ b/src/main/java/org/zzin/splitfy/domain/settlement/mapper/SettlementHistoryMapper.java
@@ -1,0 +1,46 @@
+package org.zzin.splitfy.domain.settlement.mapper;
+
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+import org.zzin.splitfy.domain.settlement.dto.response.SettlementHistoryResponse;
+import org.zzin.splitfy.domain.settlement.dto.response.SettlementPaymentResponse;
+import org.zzin.splitfy.domain.settlement.entity.Payment;
+import org.zzin.splitfy.domain.settlement.entity.Settlement;
+
+@Component
+public class SettlementHistoryMapper {
+
+  public SettlementHistoryResponse toResponse(
+      Settlement settlement,  // 정산 1건
+      List<Payment> payments, // 정산에 속한 결제들
+      Map<Long, String> userNameMap,  // userId -> username
+      Map<Long, List<String>> allocationNameMap // paymentId -> List<allocationName>
+  ) {
+
+    return new SettlementHistoryResponse(
+        settlement.getId(),
+        settlement.getTotalAmount(),
+        settlement.getStatus(),
+        settlement.getIssuedAt(),
+        settlement.getSucceededAt(),
+        settlement.getRemainder(),
+        payments.stream()
+            .map(p -> toPaymentResponse(p, userNameMap, allocationNameMap))
+            .toList()
+    );
+  }
+
+  private SettlementPaymentResponse toPaymentResponse(
+      Payment payment,
+      Map<Long, String> userNameMap,
+      Map<Long, List<String>> allocationNameMap
+  ) {
+    return new SettlementPaymentResponse(
+        payment.getTitle(),
+        payment.getPaidAmount(),
+        userNameMap.get(payment.getPayerId()),
+        allocationNameMap.getOrDefault(payment.getId(), List.of())
+    );
+  }
+}

--- a/src/main/java/org/zzin/splitfy/domain/settlement/repository/PaymentAllocationsRepository.java
+++ b/src/main/java/org/zzin/splitfy/domain/settlement/repository/PaymentAllocationsRepository.java
@@ -1,0 +1,10 @@
+package org.zzin.splitfy.domain.settlement.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.zzin.splitfy.domain.settlement.entity.PaymentAllocations;
+
+public interface PaymentAllocationsRepository extends JpaRepository<PaymentAllocations, Long> {
+
+  List<PaymentAllocations> findByPaymentIdIn(List<Long> paymentIds);
+}

--- a/src/main/java/org/zzin/splitfy/domain/settlement/repository/PaymentRepository.java
+++ b/src/main/java/org/zzin/splitfy/domain/settlement/repository/PaymentRepository.java
@@ -1,8 +1,10 @@
 package org.zzin.splitfy.domain.settlement.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.zzin.splitfy.domain.settlement.entity.Payment;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
+  List<Payment> findBySettlementIdIn(List<Long> settlementIds);
 }

--- a/src/main/java/org/zzin/splitfy/domain/settlement/repository/SettlementParticipantRepository.java
+++ b/src/main/java/org/zzin/splitfy/domain/settlement/repository/SettlementParticipantRepository.java
@@ -1,8 +1,10 @@
 package org.zzin.splitfy.domain.settlement.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.zzin.splitfy.domain.settlement.entity.SettlementParticipant;
 
 public interface SettlementParticipantRepository extends JpaRepository<SettlementParticipant, Long> {
 
+  List<SettlementParticipant> findBySettlementIdIn(List<Long> settlementIds);
 }

--- a/src/main/java/org/zzin/splitfy/domain/settlement/repository/SettlementQueryRepository.java
+++ b/src/main/java/org/zzin/splitfy/domain/settlement/repository/SettlementQueryRepository.java
@@ -1,0 +1,41 @@
+package org.zzin.splitfy.domain.settlement.repository;
+
+import static org.zzin.splitfy.domain.settlement.entity.QPayment.payment;
+import static org.zzin.splitfy.domain.settlement.entity.QPaymentAllocations.paymentAllocations;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.stereotype.Repository;
+import org.zzin.splitfy.domain.settlement.dto.PaymentAllocationDto;
+import org.zzin.splitfy.domain.settlement.dto.QPaymentAllocationDto;
+
+@Repository
+@RequiredArgsConstructor
+@NullMarked
+public class SettlementQueryRepository {
+
+  private final JPAQueryFactory queryFactory;
+
+  public List<PaymentAllocationDto> findPaymentAllocationsInSettlements(List<Long> settlementIds) {
+    return queryFactory
+        .select(new QPaymentAllocationDto(
+            payment.id,
+            payment.settlementId,
+            payment.paidAmount,
+            payment.payerId,
+            payment.shareAmount,
+            payment.title,
+            paymentAllocations.userId
+        ))
+        .from(payment)
+        .leftJoin(paymentAllocations).on(paymentAllocations.paymentId.eq(payment.id))
+        .where(payment.settlementId.in(settlementIds))
+        .orderBy(
+            payment.id.asc(),
+            paymentAllocations.userId.asc()
+        )
+        .fetch();
+  }
+}

--- a/src/main/java/org/zzin/splitfy/domain/settlement/repository/SettlementRepository.java
+++ b/src/main/java/org/zzin/splitfy/domain/settlement/repository/SettlementRepository.java
@@ -1,8 +1,26 @@
 package org.zzin.splitfy.domain.settlement.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.zzin.splitfy.domain.settlement.entity.Settlement;
 
 public interface SettlementRepository extends JpaRepository<Settlement, Long> {
 
+  @Query("""
+      select s
+      from Settlement s
+      where exists (
+            select 1 
+            from SettlementParticipant  sp
+            where sp.settlementId = s.id
+            and sp.participantId = :userId
+            )
+      """)
+  Page<Settlement> findByParticipantUserId(
+      @Param("userId") Long userId,
+      Pageable pageable
+  );
 }

--- a/src/main/java/org/zzin/splitfy/domain/settlement/service/DefaultSettlementInnerService.java
+++ b/src/main/java/org/zzin/splitfy/domain/settlement/service/DefaultSettlementInnerService.java
@@ -1,5 +1,8 @@
 package org.zzin.splitfy.domain.settlement.service;
 
+import org.springframework.stereotype.Service;
+
+@Service
 public class DefaultSettlementInnerService implements SettlementInnerService {
 
 }

--- a/src/main/java/org/zzin/splitfy/domain/settlement/service/SettlementInnerService.java
+++ b/src/main/java/org/zzin/splitfy/domain/settlement/service/SettlementInnerService.java
@@ -2,5 +2,4 @@ package org.zzin.splitfy.domain.settlement.service;
 
 public interface SettlementInnerService {
 
-
 }

--- a/src/main/java/org/zzin/splitfy/domain/settlement/service/SettlementRecordService.java
+++ b/src/main/java/org/zzin/splitfy/domain/settlement/service/SettlementRecordService.java
@@ -1,5 +1,6 @@
 package org.zzin.splitfy.domain.settlement.service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -9,8 +10,10 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.zzin.splitfy.domain.settlement.dto.request.PaymentRequest;
 import org.zzin.splitfy.domain.settlement.entity.Payment;
+import org.zzin.splitfy.domain.settlement.entity.PaymentAllocations;
 import org.zzin.splitfy.domain.settlement.entity.Settlement;
 import org.zzin.splitfy.domain.settlement.entity.SettlementParticipant;
+import org.zzin.splitfy.domain.settlement.repository.PaymentAllocationsRepository;
 import org.zzin.splitfy.domain.settlement.repository.PaymentRepository;
 import org.zzin.splitfy.domain.settlement.repository.SettlementParticipantRepository;
 import org.zzin.splitfy.domain.settlement.repository.SettlementRepository;
@@ -23,6 +26,7 @@ public class SettlementRecordService {
   private final SettlementRepository settlementRepository;
   private final PaymentRepository paymentRepository;
   private final SettlementParticipantRepository settlementParticipantRepository;
+  private final PaymentAllocationsRepository paymentAllocationsRepository;
 
   /**
    * 정산 요청에 대한 settlement, payment, participant 기록을 저장합니다.
@@ -43,29 +47,34 @@ public class SettlementRecordService {
       Map<Long, Long> netBalance
   ) {
     // Settlement 생성 및 저장
-    Settlement settlement = new Settlement(issuerId, totalAmount, totalRemainder);
-    settlement = settlementRepository.save(settlement);
+    Settlement savedSettlement = settlementRepository.save(
+        new Settlement(issuerId, totalAmount, totalRemainder)
+    );
 
-    // Payment 엔티티 생성 및 저장
+    // Payment 엔티티 생성 및 저장 + PaymentAllocations 저장
+    List<PaymentAllocations> allAllocations = new ArrayList<>();
     for (PaymentRequest paymentRequest : paymentRequests) {
-      Payment payment = settlement.createPayment(
+      Payment payment = savedSettlement.createPayment(
           paymentRequest.paidAmount(),
           paymentRequest.payerId(),
           paymentRequest.title()
       );
-      paymentRepository.save(payment);
+      payment = paymentRepository.save(payment);
+
+      // PaymentAllocations 수집 (각 payment의 정산 대상자)
+      for (Long allocationId : paymentRequest.allocationIds()) {
+        allAllocations.add(new PaymentAllocations(payment.getId(), allocationId));
+      }
     }
+    paymentAllocationsRepository.saveAll(allAllocations);
 
     // SettlementParticipant 저장 (각 사용자의 정산 금액)
-    for (Map.Entry<Long, Long> entry : netBalance.entrySet()) {
-      SettlementParticipant participant = settlement.createParticipant(
-          entry.getKey(),
-          entry.getValue()
-      );
-      settlementParticipantRepository.save(participant);
-    }
+    List<SettlementParticipant> participants = netBalance.entrySet().stream()
+        .map(entry -> savedSettlement.createParticipant(entry.getKey(), entry.getValue()))
+        .toList();
+    settlementParticipantRepository.saveAll(participants);
 
-    return settlement.getId();
+    return savedSettlement.getId();
   }
 
 }

--- a/src/main/java/org/zzin/splitfy/domain/settlement/service/SettlementService.java
+++ b/src/main/java/org/zzin/splitfy/domain/settlement/service/SettlementService.java
@@ -5,15 +5,28 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NullMarked;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.zzin.splitfy.common.dto.CommonPage;
 import org.zzin.splitfy.common.exception.BusinessException;
 import org.zzin.splitfy.common.security.AuthUser;
+import org.zzin.splitfy.domain.auth.service.AuthInnerService;
 import org.zzin.splitfy.domain.settlement.dto.request.PaymentRequest;
 import org.zzin.splitfy.domain.settlement.dto.request.SettlementRequest;
+import org.zzin.splitfy.domain.settlement.dto.response.SettlementHistoryResponse;
 import org.zzin.splitfy.domain.settlement.dto.response.SettlementResponse;
+import org.zzin.splitfy.domain.settlement.entity.Payment;
+import org.zzin.splitfy.domain.settlement.entity.PaymentAllocations;
+import org.zzin.splitfy.domain.settlement.entity.Settlement;
 import org.zzin.splitfy.domain.settlement.exception.SettlementErrorCode;
+import org.zzin.splitfy.domain.settlement.mapper.SettlementHistoryMapper;
+import org.zzin.splitfy.domain.settlement.repository.PaymentAllocationsRepository;
+import org.zzin.splitfy.domain.settlement.repository.PaymentRepository;
+import org.zzin.splitfy.domain.settlement.repository.SettlementRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +36,11 @@ public class SettlementService {
   private final SettlementTransferService settlementTransferService;
   private final SettlementStatusService settlementStatusService;
   private final SettlementRecordService settlementRecordService;
+  private final SettlementRepository settlementRepository;
+  private final PaymentRepository paymentRepository;
+  private final PaymentAllocationsRepository paymentAllocationsRepository;
+  private final AuthInnerService authInnerService;
+  private final SettlementHistoryMapper settlementHistoryMapper;
 
   public SettlementResponse createSettlement(AuthUser authUser, SettlementRequest request) {
     long issuerId = authUser.userId();
@@ -108,6 +126,77 @@ public class SettlementService {
     }
 
     return netBalance;
+  }
+
+  public CommonPage<SettlementHistoryResponse> getSettlementHistory(
+      Pageable pageable,
+      AuthUser authUser
+  ) {
+    long userId = authUser.userId();
+
+    // 1. 사용자가 참여한 정산들을 페이징 조회
+    Page<Settlement> settlementPage = settlementRepository.findByParticipantUserId(userId,
+        pageable);
+    List<Settlement> settlements = settlementPage.getContent();
+
+    if (settlements.isEmpty()) {
+      return new CommonPage<>(List.of(), settlementPage.getTotalPages());
+    }
+
+    // 2. 정산 ID 목록 추출
+    List<Long> settlementIds = settlements.stream()
+        .map(Settlement::getId)
+        .toList();
+
+    // 3. 모든 Payment 조회
+    List<Payment> payments = paymentRepository.findBySettlementIdIn(settlementIds);
+
+    // 4. Payment ID 목록 추출
+    List<Long> paymentIds = payments.stream()
+        .map(Payment::getId)
+        .toList();
+
+    // 5. 모든 PaymentAllocations 조회
+    List<PaymentAllocations> allocations = paymentAllocationsRepository.findByPaymentIdIn(
+        paymentIds);
+
+    // 6. 모든 User ID 수집 (payerId + allocationUserId)
+    Set<Long> userIds = new HashSet<>();
+    payments.forEach(payment -> userIds.add(payment.getPayerId()));
+    allocations.forEach(allocation -> userIds.add(allocation.getUserId()));
+
+    // 7. User 정보 조회 및 매핑 (userId -> username)
+    Map<Long, String> userNameMap = authInnerService.findByIdIn(userIds);
+
+    // 8. paymentId별로 allocationNames를 그룹화 (paymentId -> List<allocationName>)
+    Map<Long, List<String>> allocationNameMap = allocations.stream()
+        .collect(Collectors.groupingBy(
+            PaymentAllocations::getPaymentId,
+            Collectors.mapping(
+                allocation -> userNameMap.getOrDefault(allocation.getUserId(), "Unknown"),
+                Collectors.toList()
+            )
+        ));
+
+    // 9. settlementId별로 Payment들을 그룹화
+    Map<Long, List<Payment>> paymentsBySettlementId = payments.stream()
+        .collect(Collectors.groupingBy(Payment::getSettlementId));
+
+    // 10. Settlement -> SettlementHistoryResponse 변환
+    List<SettlementHistoryResponse> responses = settlements.stream()
+        .map(settlement -> {
+          List<Payment> settlementPayments = paymentsBySettlementId.getOrDefault(
+              settlement.getId(), List.of());
+          return settlementHistoryMapper.toResponse(
+              settlement,
+              settlementPayments,
+              userNameMap,
+              allocationNameMap
+          );
+        })
+        .toList();
+
+    return new CommonPage<>(responses, settlementPage.getTotalPages());
   }
 
   /**

--- a/src/main/java/org/zzin/splitfy/domain/settlement/service/SettlementService.java
+++ b/src/main/java/org/zzin/splitfy/domain/settlement/service/SettlementService.java
@@ -16,17 +16,16 @@ import org.zzin.splitfy.common.dto.CommonPage;
 import org.zzin.splitfy.common.exception.BusinessException;
 import org.zzin.splitfy.common.security.AuthUser;
 import org.zzin.splitfy.domain.auth.service.AuthInnerService;
+import org.zzin.splitfy.domain.settlement.dto.PaymentAllocationDto;
 import org.zzin.splitfy.domain.settlement.dto.request.PaymentRequest;
 import org.zzin.splitfy.domain.settlement.dto.request.SettlementRequest;
 import org.zzin.splitfy.domain.settlement.dto.response.SettlementHistoryResponse;
 import org.zzin.splitfy.domain.settlement.dto.response.SettlementResponse;
 import org.zzin.splitfy.domain.settlement.entity.Payment;
-import org.zzin.splitfy.domain.settlement.entity.PaymentAllocations;
 import org.zzin.splitfy.domain.settlement.entity.Settlement;
 import org.zzin.splitfy.domain.settlement.exception.SettlementErrorCode;
 import org.zzin.splitfy.domain.settlement.mapper.SettlementHistoryMapper;
-import org.zzin.splitfy.domain.settlement.repository.PaymentAllocationsRepository;
-import org.zzin.splitfy.domain.settlement.repository.PaymentRepository;
+import org.zzin.splitfy.domain.settlement.repository.SettlementQueryRepository;
 import org.zzin.splitfy.domain.settlement.repository.SettlementRepository;
 
 @Service
@@ -38,8 +37,7 @@ public class SettlementService {
   private final SettlementStatusService settlementStatusService;
   private final SettlementRecordService settlementRecordService;
   private final SettlementRepository settlementRepository;
-  private final PaymentRepository paymentRepository;
-  private final PaymentAllocationsRepository paymentAllocationsRepository;
+  private final SettlementQueryRepository settlementQueryRepository;
   private final AuthInnerService authInnerService;
   private final SettlementHistoryMapper settlementHistoryMapper;
 
@@ -144,35 +142,52 @@ public class SettlementService {
     // 2. 정산 ID 목록 추출
     List<Long> settlementIds = settlements.stream().map(Settlement::getId).toList();
 
-    // 3. 모든 Payment 조회
-    List<Payment> payments = paymentRepository.findBySettlementIdIn(settlementIds);
+    // 3. Repository를 통해 Payment와 PaymentAllocations를 한 번의 쿼리로 조회
+    List<PaymentAllocationDto> dtos = settlementQueryRepository
+        .findPaymentAllocationsInSettlements(settlementIds);
 
-    // 4. Payment ID 목록 추출
-    List<Long> paymentIds = payments.stream().map(Payment::getId).toList();
-
-    // 5. 모든 PaymentAllocations 조회
-    List<PaymentAllocations> allocations = paymentAllocationsRepository.findByPaymentIdIn(
-        paymentIds);
-
-    // 6. 모든 User ID 수집 (payerId + allocationUserId)
+    // 4. DTO에서 데이터 추출 및 그룹화
+    Map<Long, Payment> paymentMap = new HashMap<>();
+    Map<Long, List<Long>> allocationUserIdsByPayment = new HashMap<>();
     Set<Long> userIds = new HashSet<>();
-    payments.forEach(payment -> userIds.add(payment.getPayerId()));
-    allocations.forEach(allocation -> userIds.add(allocation.getUserId()));
 
-    // 7. User 정보 조회 및 매핑 (userId -> username)
+    for (PaymentAllocationDto dto : dtos) {
+      // Payment 객체 생성 (중복 제거)
+      paymentMap.computeIfAbsent(dto.paymentId(), id -> {
+        Payment p = new Payment(dto.paidAmount(), dto.payerId(), dto.shareAmount(), dto.title());
+        p.setSettlementId(dto.settlementId());
+        userIds.add(dto.payerId());
+        return p;
+      });
+
+      // Allocation User ID 수집
+      if (dto.allocationUserId() != null) {
+        allocationUserIdsByPayment.computeIfAbsent(dto.paymentId(),
+                k -> new java.util.ArrayList<>())
+            .add(dto.allocationUserId());
+        userIds.add(dto.allocationUserId());
+      }
+    }
+
+    // 5. User 정보 조회
     Map<Long, String> userNameMap = authInnerService.findByIdIn(userIds);
 
-    // 8. paymentId별로 allocationNames를 그룹화 (paymentId -> List<allocationName>)
-    Map<Long, List<String>> allocationNameMap = allocations.stream().collect(
-        Collectors.groupingBy(PaymentAllocations::getPaymentId, Collectors.mapping(
-            allocation -> userNameMap.getOrDefault(allocation.getUserId(), "Unknown"),
-            Collectors.toList())));
+    // 6. paymentId별로 allocationNames를 그룹화
+    Map<Long, List<String>> allocationNameMap = allocationUserIdsByPayment.entrySet().stream()
+        .collect(Collectors.toMap(
+            Map.Entry::getKey,
+            e -> e.getValue().stream()
+                .map(uid -> userNameMap.getOrDefault(uid, "알 수 없는 사용자"))
+                .distinct()
+                .sorted()
+                .toList()
+        ));
 
-    // 9. settlementId별로 Payment들을 그룹화
-    Map<Long, List<Payment>> paymentsBySettlementId = payments.stream()
+    // 7. settlementId별로 Payment들을 그룹화
+    Map<Long, List<Payment>> paymentsBySettlementId = paymentMap.values().stream()
         .collect(Collectors.groupingBy(Payment::getSettlementId));
 
-    // 10. Settlement -> SettlementHistoryResponse 변환
+    // 8. Settlement -> SettlementHistoryResponse 변환
     List<SettlementHistoryResponse> responses = settlements.stream().map(settlement -> {
       List<Payment> settlementPayments = paymentsBySettlementId.getOrDefault(settlement.getId(),
           List.of());

--- a/src/main/java/org/zzin/splitfy/domain/settlement/service/SettlementService.java
+++ b/src/main/java/org/zzin/splitfy/domain/settlement/service/SettlementService.java
@@ -11,6 +11,7 @@ import org.jspecify.annotations.NullMarked;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.zzin.splitfy.common.dto.CommonPage;
 import org.zzin.splitfy.common.exception.BusinessException;
 import org.zzin.splitfy.common.security.AuthUser;
@@ -104,10 +105,8 @@ public class SettlementService {
    * @param allocated   사용자별 부담금 (부담해야 하는 금액)
    * @return 사용자별 정산 금액 (양수: 받을 금액, 음수: 줘야 할 금액)
    */
-  private Map<Long, Long> calculateNetBalance(
-      Map<Long, Long> contributed,
-      Map<Long, Long> allocated
-  ) {
+  private Map<Long, Long> calculateNetBalance(Map<Long, Long> contributed,
+      Map<Long, Long> allocated) {
     Map<Long, Long> netBalance = new HashMap<>();
 
     // contributed와 allocated를 모두 고려하여 모든 사용자의 정산 금액 계산
@@ -128,10 +127,9 @@ public class SettlementService {
     return netBalance;
   }
 
-  public CommonPage<SettlementHistoryResponse> getSettlementHistory(
-      Pageable pageable,
-      AuthUser authUser
-  ) {
+  @Transactional(readOnly = true)
+  public CommonPage<SettlementHistoryResponse> getSettlementHistory(Pageable pageable,
+      AuthUser authUser) {
     long userId = authUser.userId();
 
     // 1. 사용자가 참여한 정산들을 페이징 조회
@@ -144,17 +142,13 @@ public class SettlementService {
     }
 
     // 2. 정산 ID 목록 추출
-    List<Long> settlementIds = settlements.stream()
-        .map(Settlement::getId)
-        .toList();
+    List<Long> settlementIds = settlements.stream().map(Settlement::getId).toList();
 
     // 3. 모든 Payment 조회
     List<Payment> payments = paymentRepository.findBySettlementIdIn(settlementIds);
 
     // 4. Payment ID 목록 추출
-    List<Long> paymentIds = payments.stream()
-        .map(Payment::getId)
-        .toList();
+    List<Long> paymentIds = payments.stream().map(Payment::getId).toList();
 
     // 5. 모든 PaymentAllocations 조회
     List<PaymentAllocations> allocations = paymentAllocationsRepository.findByPaymentIdIn(
@@ -169,32 +163,22 @@ public class SettlementService {
     Map<Long, String> userNameMap = authInnerService.findByIdIn(userIds);
 
     // 8. paymentId별로 allocationNames를 그룹화 (paymentId -> List<allocationName>)
-    Map<Long, List<String>> allocationNameMap = allocations.stream()
-        .collect(Collectors.groupingBy(
-            PaymentAllocations::getPaymentId,
-            Collectors.mapping(
-                allocation -> userNameMap.getOrDefault(allocation.getUserId(), "Unknown"),
-                Collectors.toList()
-            )
-        ));
+    Map<Long, List<String>> allocationNameMap = allocations.stream().collect(
+        Collectors.groupingBy(PaymentAllocations::getPaymentId, Collectors.mapping(
+            allocation -> userNameMap.getOrDefault(allocation.getUserId(), "Unknown"),
+            Collectors.toList())));
 
     // 9. settlementId별로 Payment들을 그룹화
     Map<Long, List<Payment>> paymentsBySettlementId = payments.stream()
         .collect(Collectors.groupingBy(Payment::getSettlementId));
 
     // 10. Settlement -> SettlementHistoryResponse 변환
-    List<SettlementHistoryResponse> responses = settlements.stream()
-        .map(settlement -> {
-          List<Payment> settlementPayments = paymentsBySettlementId.getOrDefault(
-              settlement.getId(), List.of());
-          return settlementHistoryMapper.toResponse(
-              settlement,
-              settlementPayments,
-              userNameMap,
-              allocationNameMap
-          );
-        })
-        .toList();
+    List<SettlementHistoryResponse> responses = settlements.stream().map(settlement -> {
+      List<Payment> settlementPayments = paymentsBySettlementId.getOrDefault(settlement.getId(),
+          List.of());
+      return settlementHistoryMapper.toResponse(settlement, settlementPayments, userNameMap,
+          allocationNameMap);
+    }).toList();
 
     return new CommonPage<>(responses, settlementPage.getTotalPages());
   }

--- a/src/main/java/org/zzin/splitfy/domain/settlement/service/SettlementTransferService.java
+++ b/src/main/java/org/zzin/splitfy/domain/settlement/service/SettlementTransferService.java
@@ -59,6 +59,7 @@ public class SettlementTransferService {
 
         // 실제 이체 실행: debtorId가 creditorId에게 transferAmount만큼 이체
         pointInnerService.transferPoint(debtorId, creditorId, transferAmount);
+
         // 잔액 업데이트
         remainingDebt -= transferAmount;
         creditorEntry.setValue(remainingCredit - transferAmount);

--- a/src/test/java/org/zzin/splitfy/domain/settlement/SettlementRecordServiceTest.java
+++ b/src/test/java/org/zzin/splitfy/domain/settlement/SettlementRecordServiceTest.java
@@ -16,8 +16,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.zzin.splitfy.domain.settlement.dto.request.PaymentRequest;
 import org.zzin.splitfy.domain.settlement.entity.Payment;
+import org.zzin.splitfy.domain.settlement.entity.PaymentAllocations;
 import org.zzin.splitfy.domain.settlement.entity.Settlement;
 import org.zzin.splitfy.domain.settlement.entity.SettlementParticipant;
+import org.zzin.splitfy.domain.settlement.repository.PaymentAllocationsRepository;
 import org.zzin.splitfy.domain.settlement.repository.PaymentRepository;
 import org.zzin.splitfy.domain.settlement.repository.SettlementParticipantRepository;
 import org.zzin.splitfy.domain.settlement.repository.SettlementRepository;
@@ -37,6 +39,9 @@ class SettlementRecordServiceTest {
 
   @Mock
   private SettlementParticipantRepository settlementParticipantRepository;
+
+  @Mock
+  private PaymentAllocationsRepository paymentAllocationsRepository;
 
   @Test
   void createSettlementRecord_정상요청시_정산과결제및참여자가저장된다() {
@@ -72,9 +77,16 @@ class SettlementRecordServiceTest {
         .willReturn(savedSettlement);
 
     given(paymentRepository.save(any(Payment.class)))
+        .willAnswer(invocation -> {
+          Payment payment = invocation.getArgument(0);
+          ReflectionTestUtils.setField(payment, "id", 1L);
+          return payment;
+        });
+
+    given(settlementParticipantRepository.saveAll(any(List.class)))
         .willAnswer(invocation -> invocation.getArgument(0));
 
-    given(settlementParticipantRepository.save(any(SettlementParticipant.class)))
+    given(paymentAllocationsRepository.saveAll(any(List.class)))
         .willAnswer(invocation -> invocation.getArgument(0));
 
     Long settlementId = settlementRecordService.createSettlementRecord(
@@ -93,7 +105,10 @@ class SettlementRecordServiceTest {
     then(paymentRepository).should(times(2))
         .save(any(Payment.class));
 
-    then(settlementParticipantRepository).should(times(2))
-        .save(any(SettlementParticipant.class));
+    then(settlementParticipantRepository).should(times(1))
+        .saveAll(any(List.class));
+
+    then(paymentAllocationsRepository).should(times(1))
+        .saveAll(any(List.class));
   }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Closes #11

<br>

## 📝 작업 내용(이미지 첨부 가능)
- 정산 내역 조회 과정에서 allocationNames 매핑을 위해 Payment 엔티티에 setId() 추가